### PR TITLE
Localization support

### DIFF
--- a/test/test-yaas-product.js
+++ b/test/test-yaas-product.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // require enviroment variables:
 // TEST_YAAS_CLIENT_ID
 // TEST_YAAS_CLIENT_SECRET
@@ -41,4 +43,69 @@ describe('Product', function () {
     })
     
   })
-})
+
+    describe('check localization', function () {
+        it('should return a map with different languages', function (done) {
+            var query = {
+                "q" : { "code": "yaasproduct1" }
+            };
+
+            yaas.product.getProducts(query)
+                .then(res => {
+                    res.body.should.be.instanceof(Array).and.have.lengthOf(1);
+                    res.body[0].should.have.property('name');
+                    res.body[0].name.should.be.instanceof(Object);
+                    res.body[0].name.should.have.property('de');
+                    res.body[0].name.should.have.property('en');
+                    done();
+                })
+        });
+
+        it('should return all languages when explicitly none is specified', function (done) {
+            var query = {
+                "q" : { "code": "yaasproduct1" }
+            };
+
+            yaas.setLanguage('');
+            yaas.product.getProducts(query)
+                .then(res => {
+                    res.body.should.be.instanceof(Array).and.have.lengthOf(1);
+                    res.body[0].should.have.property('name');
+                    res.body[0].name.should.be.instanceof(Object);
+                    res.body[0].name.should.have.property('de');
+                    res.body[0].name.should.have.property('en');
+                    done();
+                })
+        });
+
+        it('should return product name in german', function (done) {
+            var query = {
+                "q" : { "code": "yaasproduct1" }
+            };
+
+            yaas.setLanguage('de');
+            yaas.product.getProducts(query)
+                .then(res => {
+                    res.body.should.be.instanceof(Array).and.have.lengthOf(1);
+                    res.body[0].should.have.property('name');
+                    res.body[0].name.should.be.exactly('YaaS Produkt 1');
+                    done();
+                })
+        });
+
+        it('should return product name in english', function (done) {
+            var query = {
+                "q" : { "code": "yaasproduct1" }
+            };
+
+            yaas.setLanguage('en');
+            yaas.product.getProducts(query)
+                .then(res => {
+                    res.body.should.be.instanceof(Array).and.have.lengthOf(1);
+                    res.body[0].should.have.property('name');
+                    res.body[0].name.should.be.exactly('YaaS product 1');
+                    done();
+                })
+        });
+    })
+});

--- a/yaas-requesthelper.js
+++ b/yaas-requesthelper.js
@@ -12,6 +12,7 @@ var RequestHelper = function(theClientId, theClientSecret, theScope, theProjectI
     this.clientSecret= theClientSecret;
     this.scope = theScope;
     this.projectId = theProjectId;
+    this.acceptLanguage = undefined;
 
     this.getToken = function() {
 
@@ -91,6 +92,10 @@ var RequestHelper = function(theClientId, theClientSecret, theScope, theProjectI
 
     this.sendRequest = function(method, path, mime, data) {
         var headers = {};
+
+        if (this.acceptLanguage) {
+            headers['Accept-Language'] = this.acceptLanguage;
+        }
 
         if (mime) {
             headers['Content-Type'] = mime;
@@ -202,6 +207,10 @@ var RequestHelper = function(theClientId, theClientSecret, theScope, theProjectI
 
     this.setDebug = function(callback) {
       this.debugCallback = callback;
+    };
+
+    this.setLanguage = function(value) {
+        this.acceptLanguage = value;
     };
 
     this.logDebug = function(message) {

--- a/yaas.js
+++ b/yaas.js
@@ -14,10 +14,13 @@ var CouponService = require('./yaas-coupon.js');
 var LoyaltyConfigurationService = require('./yaas-loyalty-configuration.js');
 var LoyaltyMemberService = require('./yaas-loyalty-member.js');
 
+var language = undefined;
+
 var Yaas = function() {
     this.init = function(theClientId, theClientSecret, theScope, theProjectId, yaasExtensions, overrideApiUrl) {
         this.requestHelper = new RequestHelper(theClientId, theClientSecret, theScope, theProjectId, overrideApiUrl);
         this.requestHelper.setDebug(this.debugCallback);
+        this.requestHelper.setLanguage(language);
         this.cart = new CartService(this.requestHelper);
         this.checkout = new CheckoutService(this.requestHelper);
         this.customer = new CustomerService(this.requestHelper);
@@ -45,6 +48,13 @@ var Yaas = function() {
     this.setDebugCallback = function(callback) {
         this.debugCallback = callback;
     };
+
+    this.setLanguage = function(value) {
+        language = value;
+        if (this.requestHelper) {
+            this.requestHelper.setLanguage(value);
+        }
+    }
 };
 
 module.exports = Yaas;


### PR DESCRIPTION
Product service v1 assumed english as a default when the API was called without a `Accept-Language` header. This is not the case anymore with v2 (see https://devportal.yaas.io/rn/services/product/latest/2016-03-04-ReleaseNotesProduct.html)

This pull request tries to enable the user of the SDK to set the desired language for the queries.
