### PR TITLE
Adding HTTP HEAD support, and getCount to yaas-document.js

### DIFF
--- a/yaas-document.js
+++ b/yaas-document.js
@@ -9,6 +9,10 @@ var Document = function(rh) {
     return this.requestHelper.get(pathDocumentBase + '/' + applicationId + '/data/' + documentType, queryParameters);
   };
 
+  this.getCount = function(applicationId, documentType, queryParameters) {
+    return this.requestHelper.head(pathDocumentBase + '/' + applicationId + '/data/' + documentType, queryParameters);
+  };
+
   this.get = function(applicationId, documentType, documentId, queryParameters) {
     return this.requestHelper.get(
       pathDocumentBase + '/' + applicationId + '/data/' + documentType + '/' + documentId, 

--- a/yaas-requesthelper.js
+++ b/yaas-requesthelper.js
@@ -151,6 +151,12 @@ var RequestHelper = function(theClientId, theClientSecret, theScope, theProjectI
         return this.sendRequest('GET', pathWithParams, null, {});
     };
 
+    this.head = function(path, params) {
+        var queryParamString = querystring.stringify(params);
+        var pathWithParams = path + (queryParamString.length > 0 ? '?' + queryParamString : '');
+        return this.sendRequest('HEAD', pathWithParams, null, {});
+    };
+
     this.post = function(path, mime, postData) {
         return this.sendRequest('POST', path, mime, this.prepareData(postData, mime));
     };
@@ -190,7 +196,7 @@ var RequestHelper = function(theClientId, theClientSecret, theScope, theProjectI
             break;
           case 'application/json':
             try {
-              responseBody = JSON.parse(response.body);
+              responseBody = response.body ? JSON.parse(response.body) : null;
             } catch (e) {
               reject('Could not read server response: ' + e.message);
             }


### PR DESCRIPTION
Some services endpoints use the HEAD http method to return number of objects.

For example:
 [/{tenant}/{client}/data/{type}](https://devportal.yaas.io/services/beta/document/latest/index.html#tenant___client__data__type__head)

Line 199 in **yaas-requesthelper.js** changed to support responses without body:
`responseBody = response.body ? JSON.parse(response.body) : null;`